### PR TITLE
Add curl package to base image

### DIFF
--- a/build/elasticsearch-alpine-base/Dockerfile
+++ b/build/elasticsearch-alpine-base/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 # Update image and install base packages
 RUN apk update && \
     apk upgrade && \
-    apk add bash openjdk8 openssl && \
+    apk add bash openjdk8 openssl curl && \
     rm -rf /var/cache/apk/*
 
 # Install elasticsearch user

--- a/build/elasticsearch-alpine-base/Dockerfile
+++ b/build/elasticsearch-alpine-base/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 # Update image and install base packages
 RUN apk update && \
     apk upgrade && \
-    apk add bash openjdk8 openssl curl && \
+    apk add bash curl openjdk8 openssl && \
     rm -rf /var/cache/apk/*
 
 # Install elasticsearch user


### PR DESCRIPTION
curl package was missing from the base repo. we need this package to enabled, so that we can fetch host's private ip in ECS  

AWS_PRIVATE_IP=`curl http://169.254.169.254/latest/meta-data/local-ipv4`

exec bin/elasticsearch ${es_opts} -Enetwork.publish_host=$AWS_PRIVATE_IP
